### PR TITLE
Refactoring the EventHandler to only handle a single event, which is …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shrev"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Simon Rönnberg <simon.ronnberg@codemill.se>"]
 repository = "https://github.com/Rhuagh/shrev-rs.git"
 homepage = "https://github.com/Rhuagh/shrev-rs.git"
@@ -8,12 +8,11 @@ homepage = "https://github.com/Rhuagh/shrev-rs.git"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 documentation = "https://docs.rs/shrev"
-description = "Event handler, using shred for synchronization, allowing immutable reads."
+description = "Event handler, meant to be used with `specs`."
 
-keywords = ["shred", "events"]
+keywords = ["specs", "events"]
 
 [dependencies]
-shred = "0.4"
 
 [[example]]
 name = "basic"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A pull based event handler, with events stored in a ring buffer,
- using [Shred][shred] for synchronization.
+ meant to be used as a resource in [`specs`](specs).
  
-[shred]: https://github.com/slide-rs/shred
+[specs]: https://github.com/slide-rs/specs
 
 Example
 
@@ -12,40 +12,33 @@ use shrev::EventHandler;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TestEvent {
-    data : u32
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TestEvent2 {
-    data : u32
+    data: u32,
 }
 
 fn main() {
     let mut event_handler = EventHandler::new();
-    event_handler.register::<TestEvent>();
-    event_handler.register::<TestEvent2>();
-    let mut reader_id_2 = event_handler.register_reader::<TestEvent2>().unwrap();
 
-    event_handler.write(&mut vec![TestEvent { data : 1}, TestEvent { data : 2}]).expect("");
-    event_handler.write(&mut vec![TestEvent2 { data : 3}, TestEvent2 { data : 4}]).expect("");
+    event_handler
+        .write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }])
+        .expect("");
 
-    let mut reader_id_1 = event_handler.register_reader::<TestEvent>().unwrap();
+    let mut reader_id = event_handler.register_reader();
 
-    // Should have data, as reader was created before the first write
-    assert_eq!(Ok([TestEvent2 { data: 3 }, TestEvent2 { data: 4 }].to_vec()),
-               event_handler.read::<TestEvent2>(&mut reader_id_2));
-
-    // Should be empty, because no write was done after previous read
-    assert_eq!(Ok([].to_vec()), event_handler.read::<TestEvent2>(&mut reader_id_2));
 
     // Should be empty, because reader was created after the write
-    assert_eq!(Ok([].to_vec()), event_handler.read::<TestEvent>(&mut reader_id_1));
+    assert_eq!(
+        Ok([].to_vec()),
+        event_handler.read(&mut reader_id)
+    );
 
-    event_handler.write(&mut vec![TestEvent2 { data : 8}, TestEvent2 { data : 9}]).expect("");
+    event_handler
+        .write(&mut vec![TestEvent { data: 8 }, TestEvent { data: 9 }])
+        .expect("");
 
     // Should have data, as a second write was done
-    assert_eq!(Ok([TestEvent2 { data: 8 }, TestEvent2 { data: 9 }].to_vec()),
-               event_handler.read::<TestEvent2>(&mut reader_id_2));
-
+    assert_eq!(
+        Ok([TestEvent { data: 8 }, TestEvent { data: 9 }].to_vec()),
+        event_handler.read(&mut reader_id)
+    );
 }
 ```

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,51 +7,26 @@ pub struct TestEvent {
     data: u32,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TestEvent2 {
-    data: u32,
-}
-
 fn main() {
     let mut event_handler = EventHandler::new();
-    event_handler.register::<TestEvent>();
-    event_handler.register::<TestEvent2>();
-    let mut reader_id_2 = event_handler.register_reader::<TestEvent2>().unwrap();
 
     event_handler
         .write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }])
         .expect("");
-    event_handler
-        .write(&mut vec![TestEvent2 { data: 3 }, TestEvent2 { data: 4 }])
-        .expect("");
 
-    let mut reader_id_1 = event_handler.register_reader::<TestEvent>().unwrap();
+    let mut reader_id = event_handler.register_reader();
 
-    // Should have data, as reader was created before the first write
-    assert_eq!(
-        Ok([TestEvent2 { data: 3 }, TestEvent2 { data: 4 }].to_vec()),
-        event_handler.read::<TestEvent2>(&mut reader_id_2)
-    );
-
-    // Should be empty, because no write was done after previous read
-    assert_eq!(
-        Ok([].to_vec()),
-        event_handler.read::<TestEvent2>(&mut reader_id_2)
-    );
 
     // Should be empty, because reader was created after the write
-    assert_eq!(
-        Ok([].to_vec()),
-        event_handler.read::<TestEvent>(&mut reader_id_1)
-    );
+    assert_eq!(Ok([].to_vec()), event_handler.read(&mut reader_id));
 
     event_handler
-        .write(&mut vec![TestEvent2 { data: 8 }, TestEvent2 { data: 9 }])
+        .write(&mut vec![TestEvent { data: 8 }, TestEvent { data: 9 }])
         .expect("");
 
     // Should have data, as a second write was done
     assert_eq!(
-        Ok([TestEvent2 { data: 8 }, TestEvent2 { data: 9 }].to_vec()),
-        event_handler.read::<TestEvent2>(&mut reader_id_2)
+        Ok([TestEvent { data: 8 }, TestEvent { data: 9 }].to_vec()),
+        event_handler.read(&mut reader_id)
     );
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports_in_group=true
+reorder_import_names=true
+reorder_imports=true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 
 #![deny(missing_docs)]
 
-extern crate shred;
-
 pub use storage::ReaderId;
 
 use std::fmt::Debug;
@@ -28,8 +26,11 @@ where
 const DEFAULT_MAX_SIZE: usize = 200;
 
 /// Event handler for managing many separate event types.
-pub struct EventHandler {
-    res: shred::Resources,
+pub struct EventHandler<E>
+where
+    E: Debug,
+{
+    storage: RingBufferStorage<E>,
 }
 
 /// Possible errors returned by the EventHandler
@@ -42,9 +43,6 @@ pub enum EventError<E: Event> {
     LostData(Vec<E>, usize),
     /// If attempting to use a reader for a different data type than the storage contains.
     InvalidReader,
-    /// If attempting to read/write events or register a reader for an event type that has not been
-    /// registered.
-    InvalidEventType,
 }
 
 impl<E: Event> Into<EventError<E>> for RBError<E> {
@@ -57,173 +55,88 @@ impl<E: Event> Into<EventError<E>> for RBError<E> {
     }
 }
 
-impl EventHandler {
-    /// Create a new EventHandler
-    pub fn new() -> EventHandler {
-        EventHandler {
-            res: shred::Resources::new(),
+impl<E> EventHandler<E>
+where
+    E: Event,
+{
+    /// Create a new EventHandler with a default size of 200
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MAX_SIZE)
+    }
+
+    /// Create a new EventHandler with the given max size
+    pub fn with_capacity(size: usize) -> Self {
+        Self {
+            storage: RingBufferStorage::new(size),
         }
     }
 
-    /// Register an event type.
-    ///
-    /// This will register the event type and allocate ringbuffer storage for the event type with
-    /// a default max size of 200 events. Once the 200 mark is reached, and a reader has still not
-    /// read the events, the buffer will overflow, and the reader will get an error on the next
-    /// read.
-    pub fn register<E: Event>(&mut self) {
-        self.register_with_size::<E>(DEFAULT_MAX_SIZE);
-    }
-
-    /// Register an event type, with a given maximum number of events before overflowing.
-    ///
-    /// This will register the event type and allocate ringbuffer storage for the event type with
-    /// the given size. Once that size mark is reached, and a reader has still not read the events,
-    /// the buffer will overflow, and the reader will get an error on the next read.
-    pub fn register_with_size<E: Event>(&mut self, max_size: usize) {
-        use shred::ResourceId;
-
-        if self.res
-            .has_value(ResourceId::new::<RingBufferStorage<E>>())
-        {
-            return;
-        }
-
-        self.res.add(RingBufferStorage::<E>::new(max_size));
-    }
-
-    /// Register a reader of an event type.
+    /// Register a reader.
     ///
     /// To be able to read events, a reader id is required. This is because otherwise the handler
     /// wouldn't know where in the ringbuffer the reader has read to earlier. This information is
     /// stored in the reader id.
-    pub fn register_reader<E: Event>(&mut self) -> Result<ReaderId, EventError<E>> {
-        match self.res.try_fetch_mut::<RingBufferStorage<E>>(0) {
-            Some(ref mut storage) => Ok(storage.new_reader_id()),
-            None => Err(EventError::InvalidEventType),
-        }
+    pub fn register_reader(&mut self) -> ReaderId {
+        self.storage.new_reader_id()
     }
 
     /// Write a number of events into its storage.
-    pub fn write<E: Event>(&mut self, events: &mut Vec<E>) -> Result<(), EventError<E>> {
+    pub fn write(&mut self, events: &mut Vec<E>) -> Result<(), EventError<E>> {
         if events.len() == 0 {
             return Ok(());
         }
-        match self.res.try_fetch_mut::<RingBufferStorage<E>>(0) {
-            Some(ref mut storage) => match storage.write(events) {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err.into()),
-            },
-            None => Err(EventError::InvalidEventType),
-        }
+
+        self.storage.write(events).map_err(|e| e.into())
     }
 
-    /// Write a single event into its storage.
-    pub fn write_single<E: Event>(&mut self, event: E) -> Result<(), EventError<E>> {
-        match self.res.try_fetch_mut::<RingBufferStorage<E>>(0) {
-            Some(ref mut storage) => {
-                storage.write_single(event);
-                Ok(())
-            }
-            None => Err(EventError::InvalidEventType),
-        }
+    /// Write a single event into storage.
+    pub fn write_single(&mut self, event: E) {
+        self.storage.write_single(event);
     }
 
     /// Read any events that have been written to storage since the readers last read.
-    pub fn read<E: Event>(&self, reader_id: &mut ReaderId) -> Result<Vec<E>, EventError<E>> {
-        match self.res.try_fetch::<RingBufferStorage<E>>(0) {
-            Some(ref storage) => match storage.read(reader_id) {
-                Ok(data) => Ok(data),
-                Err(err) => Err(err.into()),
-            },
-            None => Err(EventError::InvalidEventType),
-        }
+    pub fn read(&self, reader_id: &mut ReaderId) -> Result<Vec<E>, EventError<E>> {
+        self.storage.read(reader_id).map_err(|e| e.into())
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use std::any::TypeId;
-
     use super::*;
+    use std::any::TypeId;
 
     #[derive(Debug, Clone, PartialEq)]
     struct Test {
         pub id: u32,
     }
 
-    #[derive(Debug, Clone, PartialEq)]
-    struct Test2 {
-        pub id: u32,
-    }
-
-    #[test]
-    fn test_register() {
-        let mut handler = EventHandler::new();
-        handler.register::<Test>();
-        handler.register::<Test2>();
-    }
-
-    #[test]
-    fn test_register_with_size() {
-        let mut handler = EventHandler::new();
-        handler.register_with_size::<Test>(14);
-        handler.register_with_size::<Test2>(14);
-    }
-
     #[test]
     fn test_register_reader() {
-        let mut handler = EventHandler::new();
-        handler.register_with_size::<Test>(14);
-        let reader_id = handler.register_reader::<Test>();
-        assert_eq!(Ok(ReaderId::new(TypeId::of::<Test>(), 1, 0, 0)), reader_id);
-    }
-
-    #[test]
-    fn test_write_without_register() {
-        let mut handler = EventHandler::new();
-        assert_eq!(
-            Err(EventError::InvalidEventType),
-            handler.write_single(Test { id: 1 })
-        );
-    }
-
-    #[test]
-    fn test_register_reader_without_register() {
-        let mut handler = EventHandler::new();
-        assert_eq!(
-            Err(EventError::InvalidEventType),
-            handler.register_reader::<Test>()
-        );
+        let mut handler = EventHandler::<Test>::with_capacity(14);
+        let reader_id = handler.register_reader();
+        assert_eq!(ReaderId::new(TypeId::of::<Test>(), 1, 0, 0), reader_id);
     }
 
     #[test]
     fn test_read_write() {
-        let mut handler = EventHandler::new();
-        handler.register_with_size::<Test>(14);
-        handler.register_with_size::<Test2>(14);
+        let mut handler = EventHandler::with_capacity(14);
 
-        let mut reader_id = handler.register_reader::<Test>().unwrap();
-        let mut reader_id_extra = handler.register_reader::<Test>().unwrap();
-        let mut reader_id_2 = handler.register_reader::<Test2>().unwrap();
+        let mut reader_id = handler.register_reader();
+        let mut reader_id_extra = handler.register_reader();
 
-        assert_eq!(Ok(()), handler.write_single(Test { id: 1 }));
+        handler.write_single(Test { id: 1 });
         assert_eq!(Ok(vec![Test { id: 1 }]), handler.read(&mut reader_id));
-        assert_eq!(Ok(Vec::<Test2>::default()), handler.read(&mut reader_id_2));
 
-        assert_eq!(Ok(()), handler.write_single(Test { id: 2 }));
+        handler.write_single(Test { id: 2 });
         assert_eq!(Ok(vec![Test { id: 2 }]), handler.read(&mut reader_id));
-        assert_eq!(Ok(Vec::<Test2>::default()), handler.read(&mut reader_id_2));
         assert_eq!(
             Ok(vec![Test { id: 1 }, Test { id: 2 }]),
             handler.read(&mut reader_id_extra)
         );
 
-        assert_eq!(Ok(()), handler.write_single(Test { id: 3 }));
-        assert_eq!(Ok(()), handler.write_single(Test2 { id: 6 }));
+        handler.write_single(Test { id: 3 });
         assert_eq!(Ok(vec![Test { id: 3 }]), handler.read(&mut reader_id));
-        assert_eq!(Ok(vec![Test2 { id: 6 }]), handler.read(&mut reader_id_2));
         assert_eq!(Ok(vec![Test { id: 3 }]), handler.read(&mut reader_id_extra));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 
 pub use storage::ReaderId;
 
-use std::fmt::Debug;
-
 use storage::{RBError, RingBufferStorage};
 
 mod storage;
@@ -16,20 +14,18 @@ mod storage;
 /// Marker trait for data to use with the EventHandler.
 ///
 /// Has an implementation for all types where its bounds are satisfied.
-pub trait Event: Debug + Send + Sync + Clone + 'static {}
+pub trait Event: Send + Sync + Clone + 'static {}
+
 impl<T> Event for T
 where
-    T: Debug + Send + Sync + Clone + 'static,
+    T: Send + Sync + Clone + 'static,
 {
 }
 
 const DEFAULT_MAX_SIZE: usize = 200;
 
 /// Event handler for managing many separate event types.
-pub struct EventHandler<E>
-where
-    E: Debug,
-{
+pub struct EventHandler<E> {
     storage: RingBufferStorage<E>,
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,8 @@
 //! Ring buffer implementation, that does immutable reads.
 
-use std::ops::{Index, IndexMut};
 use std::any::TypeId;
 use std::fmt::Debug;
+use std::ops::{Index, IndexMut};
 
 /// Ringbuffer errors
 #[derive(Debug, PartialEq)]
@@ -161,9 +161,8 @@ impl<T: Debug> IndexMut<usize> for RingBufferStorage<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::any::TypeId;
-
     use super::*;
+    use std::any::TypeId;
 
     #[derive(Debug, Clone, PartialEq)]
     struct Test {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,12 +1,11 @@
 //! Ring buffer implementation, that does immutable reads.
 
 use std::any::TypeId;
-use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 
 /// Ringbuffer errors
-#[derive(Debug, PartialEq)]
-pub enum RBError<T: Debug> {
+#[derive(PartialEq, Debug)]
+pub enum RBError<T> {
     /// If a writer tries to write more data than the max size of the ringbuffer, in a single call
     TooLargeWrite,
     /// If a reader is more than the entire ringbuffer behind in reading, this will be returned.
@@ -38,7 +37,7 @@ impl ReaderId {
 }
 
 /// Ring buffer, holding data of type `T`
-pub struct RingBufferStorage<T: Debug> {
+pub struct RingBufferStorage<T> {
     data: Vec<T>,
     write_index: usize,
     max_size: usize,
@@ -47,7 +46,7 @@ pub struct RingBufferStorage<T: Debug> {
     reset_written: usize,
 }
 
-impl<T: Debug + Clone + 'static> RingBufferStorage<T> {
+impl<T: Clone + 'static> RingBufferStorage<T> {
     /// Create a new ring buffer with the given max size.
     pub fn new(size: usize) -> Self {
         RingBufferStorage {
@@ -145,7 +144,7 @@ impl<T: Debug + Clone + 'static> RingBufferStorage<T> {
     }
 }
 
-impl<T: Debug> Index<usize> for RingBufferStorage<T> {
+impl<T> Index<usize> for RingBufferStorage<T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -153,7 +152,7 @@ impl<T: Debug> Index<usize> for RingBufferStorage<T> {
     }
 }
 
-impl<T: Debug> IndexMut<usize> for RingBufferStorage<T> {
+impl<T> IndexMut<usize> for RingBufferStorage<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.data[index]
     }


### PR DESCRIPTION
…a type parameter of the EventHandler. This is to enable concurrency when used with specs.