### PR TITLE
Remove Copy from ReaderId, add write_slice and rename write to drain_vec_write

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut event_handler = EventHandler::new();
 
     event_handler
-        .write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }])
+        .drain_vec_write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }])
         .expect("");
 
     let mut reader_id = event_handler.register_reader();
@@ -26,7 +26,7 @@ fn main() {
     }
 
     event_handler
-        .write(&mut vec![TestEvent { data: 8 }, TestEvent { data: 9 }])
+        .drain_vec_write(&mut vec![TestEvent { data: 8 }, TestEvent { data: 9 }])
         .expect("");
 
     // Should have data, as a second write was done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,16 @@ where
         self.storage.new_reader_id()
     }
 
-    /// Write a number of events into its storage.
-    pub fn write(&mut self, events: &mut Vec<E>) -> Result<(), EventError> {
-        if events.len() == 0 {
-            return Ok(());
-        }
+    /// Write a slice of events into storage
+    pub fn write_slice(&mut self, events: &[E]) -> Result<(), EventError>
+    where E: Clone,
+    {
+        self.storage.write_slice(events)
+    }
 
-        self.storage.write(events)
+    /// Drain a vector of events into storage.
+    pub fn drain_vec_write(&mut self, events: &mut Vec<E>) -> Result<(), EventError> {
+        self.storage.drain_vec_write(events)
     }
 
     /// Write a single event into storage.


### PR DESCRIPTION
I didn't like the idea that an allocation was considered part of the "default" write so I added `write_slice` and renamed write to `drain_vec_write`.  I also removed the foot gun of ReaderId being Copy.