### PR TITLE
Derive Debug for ReadData

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -32,6 +32,7 @@ impl ReaderId {
 }
 
 /// Ring buffer, holding data of type `T`
+#[derive(Debug)]
 pub struct RingBufferStorage<T> {
     pub(crate) data: Vec<T>,
     write_index: usize,
@@ -141,6 +142,7 @@ impl<T: 'static> RingBufferStorage<T> {
 }
 
 /// Wrapper for read data. Needed because of overflow situations.
+#[derive(Debug)]
 pub enum ReadData<'a, T: 'a> {
     /// Normal read scenario, only contains an `Iterator` over the data.
     Data(StorageIterator<'a, T>),
@@ -151,6 +153,7 @@ pub enum ReadData<'a, T: 'a> {
 }
 
 /// Iterator over a slice of data in `RingBufferStorage`.
+#[derive(Debug)]
 pub struct StorageIterator<'a, T: 'a> {
     storage: &'a RingBufferStorage<T>,
     current: usize,


### PR DESCRIPTION
Hiya, I'm wondering if you'll be fine with deriving `Debug` for `ReadData`. I'm using it in one of my test assertions, and it would be nice to show not just "expected *Something*", but also "but was *Something Else*".

Tangential question, does the debug trait propagate through `amethyst`'s re-export?