### PR TITLE
Implement dynamic buffer resizing

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,14 +10,33 @@ pub struct TestEvent {
 fn main() {
     let mut channel = EventChannel::new();
 
-    channel
-        .drain_vec_write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }]);
+    channel.drain_vec_write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }]);
 
     let mut reader_id = channel.register_reader();
 
     // Should be empty, because reader was created after the write
     assert_eq!(
         Vec::<TestEvent>::default(),
+        channel.read(&mut reader_id).cloned().collect::<Vec<_>>()
+    );
+
+    // Should have data, as a second write was done
+    channel.single_write(TestEvent { data: 5 });
+
+    assert_eq!(
+        vec![TestEvent { data: 5 }],
+        channel.read(&mut reader_id).cloned().collect::<Vec<_>>()
+    );
+
+    // We can also just send in an iterator.
+    channel.iter_write(
+        [TestEvent { data: 8 }, TestEvent { data: 9 }]
+            .iter()
+            .cloned(),
+    );
+
+    assert_eq!(
+        vec![TestEvent { data: 8 }, TestEvent { data: 9 }],
         channel.read(&mut reader_id).cloned().collect::<Vec<_>>()
     );
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 extern crate shrev;
 
-use shrev::{EventChannel, EventReadData};
+use shrev::EventChannel;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TestEvent {
@@ -11,30 +11,13 @@ fn main() {
     let mut channel = EventChannel::new();
 
     channel
-        .drain_vec_write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }])
-        .expect("");
+        .drain_vec_write(&mut vec![TestEvent { data: 1 }, TestEvent { data: 2 }]);
 
     let mut reader_id = channel.register_reader();
 
     // Should be empty, because reader was created after the write
-    match channel.read(&mut reader_id) {
-        EventReadData::Data(data) => assert_eq!(
-            Vec::<TestEvent>::default(),
-            data.cloned().collect::<Vec<_>>()
-        ),
-        _ => panic!(),
-    }
-
-    channel
-        .slice_write(&mut [TestEvent { data: 8 }, TestEvent { data: 9 }])
-        .expect("");
-
-    // Should have data, as a second write was done
     assert_eq!(
-        vec![TestEvent { data: 8 }, TestEvent { data: 9 }],
-        channel
-            .lossy_read(&mut reader_id)
-            .cloned()
-            .collect::<Vec<_>>()
+        Vec::<TestEvent>::default(),
+        channel.read(&mut reader_id).cloned().collect::<Vec<_>>()
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ where
     }
 
     /// Write a slice of events into storage
-    #[deprecated]
+    #[deprecated(note="please use `iter_write` instead")]
     pub fn slice_write(&mut self, events: &[E])
     where
         E: Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ where
 {
 }
 
-const DEFAULT_MAX_SIZE: usize = 200;
+const DEFAULT_CAPACITY: usize = 50;
 
 /// Event channel
 pub struct EventChannel<E> {
@@ -36,7 +36,7 @@ where
 {
     /// Create a new EventChannel with a default size of 200
     pub fn new() -> Self {
-        Self::with_capacity(DEFAULT_MAX_SIZE)
+        Self::with_capacity(DEFAULT_CAPACITY)
     }
 
     /// Create a new EventChannel with the given starting capacity.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -110,14 +110,14 @@ impl<T: 'static> RingBufferStorage<T> {
             let (longest_reader, num_written) = self.reader_internal
                 .iter()
                 .map(|ref internal| unsafe {&*internal.get()})
-                .filter_map(|internal| {
+                .enumerate()
+                .filter_map(|(i, internal)| {
                     if internal.alive.load(Ordering::Relaxed) {
-                        Some(&internal.written)
+                        Some((i, &internal.written))
                     } else {
                         None
                     }
                 })
-                .enumerate()
                 .fold((0, 0), |(index, max_written), (i, &written)| {
                     let num_written = if self.written < written {
                         self.written + (self.reset_written - written)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -179,7 +179,7 @@ impl<T: 'static> RingBufferStorage<T> {
     /// Read data from the ringbuffer, starting where the last read ended, and up to where the last
     /// data was written.
     pub fn read(&self, reader_id: &mut ReaderId<T>) -> StorageIterator<T> {
-        debug_assert!(
+        assert!(
             reader_id.buffer_id == self.buffer_id,
             "ReaderID used with an event buffer it's not registered to.  Not permitted!"
         );

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -57,6 +57,8 @@ pub struct RingBufferStorage<T> {
     reset_written: usize,
 }
 
+unsafe impl<T> Sync for RingBufferStorage<T> where T: Sync {}
+
 impl<T: 'static> RingBufferStorage<T> {
     /// Create a new ring buffer with the given max size.
     pub fn new(size: usize) -> Self {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -366,6 +366,21 @@ mod tests {
         );
     }
 
+    /// If you're getting a compilation error here this test has failed!
+    #[test]
+    fn test_send_sync() {
+        trait SendSync: Send + Sync {
+            fn is_send_sync() -> bool;
+        }
+
+        impl<T> SendSync for T where T: Send + Sync {
+            fn is_send_sync() -> bool { true }
+        }
+
+        assert!(RingBufferStorage::<Test>::is_send_sync());
+        assert!(ReaderId::<Test>::is_send_sync());
+    }
+
     #[test]
     fn test_reader_reuse() {
         let mut buffer = RingBufferStorage::<Test>::new(3);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,25 +2,41 @@
 
 use std::marker;
 use std::ops::{Index, IndexMut};
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 /// The reader id is used by readers to tell the storage where the last read ended.
-#[derive(Hash, PartialEq, Clone, Debug)]
+#[derive(Debug)]
 pub struct ReaderId<T> {
     reader_id: usize,
     buffer_id: usize,
+    alive: Arc<AtomicBool>,
     m: marker::PhantomData<T>,
 }
 
 impl<T> ReaderId<T> {
     /// Create a new reader id
-    pub fn new(reader_id: usize, buffer_id: usize) -> ReaderId<T> {
+    pub fn new(reader_id: usize, buffer_id: usize, alive: Arc<AtomicBool>) -> ReaderId<T> {
         ReaderId {
             reader_id,
             buffer_id,
+            alive,
             m: marker::PhantomData,
         }
     }
+}
+
+impl<T> Drop for ReaderId<T> {
+    fn drop(&mut self) {
+        self.alive.store(false, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug)]
+struct InternalReaderId {
+    written: usize,
+    index: usize,
+    alive: Arc<AtomicBool>,
 }
 
 /// This static value helps assign unique ids to every storage which are then propagated to
@@ -34,8 +50,7 @@ static RING_BUFFER_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 pub struct RingBufferStorage<T> {
     pub(crate) data: Vec<T>,
     buffer_id: usize,
-    reader_written: Vec<usize>,
-    reader_indices: Vec<usize>,
+    reader_internal: Vec<InternalReaderId>,
     write_index: usize,
     written: usize,
     reset_written: usize,
@@ -47,8 +62,7 @@ impl<T: 'static> RingBufferStorage<T> {
         RingBufferStorage {
             data: Vec::with_capacity(size),
             buffer_id: RING_BUFFER_ID.fetch_add(1, Ordering::Relaxed),
-            reader_written: Vec::new(),
-            reader_indices: Vec::new(),
+            reader_internal: Vec::new(),
             write_index: 0,
             written: 0,
             reset_written: size * 1000,
@@ -72,72 +86,127 @@ impl<T: 'static> RingBufferStorage<T> {
 
     /// Write a single data point into the ringbuffer.
     pub fn single_write(&mut self, data: T) {
+        // If there are no living readers do nothing.
+        if self.reader_internal
+            .iter()
+            .all(|ref internal| !internal.alive.load(Ordering::Relaxed))
+        {
+            return;
+        }
         self.written += 1;
-        let need_growth = self.reader_written.iter().any(|&written| {
-            let num_written = if self.written < written {
-                self.written + (self.reset_written - written)
-            } else {
-                self.written - written
-            };
-            num_written > self.data.len()
-        });
+        if self.written > self.reset_written {
+            self.written = 0;
+        }
+        let need_growth = self.reader_internal
+            .iter()
+            .filter_map(|ref internal| {
+                if internal.alive.load(Ordering::Relaxed) {
+                    Some(&internal.written)
+                } else {
+                    None
+                }
+            })
+            .any(|&written| {
+                let num_written = if self.written < written {
+                    self.written + (self.reset_written - written)
+                } else {
+                    self.written - written
+                };
+                num_written > self.data.len()
+            });
         if need_growth || self.data.len() == 0 {
             self.data.insert(self.write_index, data);
-            for i in 0..self.reader_indices.len() {
-                if self.reader_indices[i] > self.write_index {
-                    self.reader_indices[i] += 1;
+            // In order to avoid pushing events that have already been read back into a readable
+            // range we're also going to push any readers that are ahead of us in the buffer
+            // forward one as well.
+            for i in 0..self.reader_internal.len() {
+                if self.reader_internal[i].index > self.write_index {
+                    self.reader_internal[i].index += 1;
                 }
             }
         } else {
+            // Check if we need to loop the write index.
             if self.write_index >= self.data.len() {
+                // If we're looping the write index then the meaning of any read indices at the end
+                // has changed, so we need to loop them too.
+                for i in 0..self.reader_internal.len() {
+                    if self.reader_internal[i].index == self.write_index {
+                        self.reader_internal[i].index = 0;
+                    }
+                }
+                // Loop the write index
                 self.write_index = 0;
             }
             self.data[self.write_index] = data;
         }
         self.write_index += 1;
-        if self.write_index >= self.data.len() && !need_growth {
-            self.write_index = 0;
-        }
-        if self.written > self.reset_written {
-            self.written = 0;
-        }
     }
 
     /// Create a new reader id for this ringbuffer.
     pub fn new_reader_id(&mut self) -> ReaderId<T> {
-        let new_id = self.reader_written.len();
-        self.reader_written.push(self.written);
-        self.reader_indices.push(self.write_index);
-        ReaderId::new(new_id, self.buffer_id)
+        let alive = Arc::new(AtomicBool::new(true));
+        // Attempt to re-use positions from dropped readers.
+        let new_id = self.reader_internal
+            .iter()
+            .position(|internal| !internal.alive.load(Ordering::Relaxed));
+        match new_id {
+            Some(new_id) => {
+                self.reader_internal[new_id] = InternalReaderId {
+                    written: self.written,
+                    index: self.write_index,
+                    alive: alive.clone(),
+                }
+            }
+            None => self.reader_internal.push(InternalReaderId {
+                written: self.written,
+                index: self.write_index,
+                alive: alive.clone(),
+            }),
+        }
+        ReaderId::new(
+            new_id.unwrap_or(self.reader_internal.len() - 1),
+            self.buffer_id,
+            alive,
+        )
     }
 
     /// Read data from the ringbuffer, starting where the last read ended, and up to where the last
     /// data was written.
     pub fn read(&self, reader_id: &mut ReaderId<T>) -> StorageIterator<T> {
-        if reader_id.buffer_id != self.buffer_id {
-            panic!("ReaderID used with an event buffer it's not registered to.  Not permitted!");
-        }
+        debug_assert!(
+            reader_id.buffer_id == self.buffer_id,
+            "ReaderID used with an event buffer it's not registered to.  Not permitted!"
+        );
+        let written = self.reader_internal[reader_id.reader_id].written;
+        let num_written = if self.written < written {
+            self.written + (self.reset_written - written)
+        } else {
+            self.written - written
+        };
 
-        let read_index = self.reader_indices[reader_id.reader_id];
-
+        // read index is sometimes kept at maximum in case the buffer grows, but if the buffer
+        // hasn't grown then we need to interpret the maximum index as 0.
+        let read_index = if self.reader_internal[reader_id.reader_id].index == self.data.len() {
+            0
+        } else {
+            self.reader_internal[reader_id.reader_id].index
+        };
         // Update the reader indice inside the storage.  This is safe because the only time this
         // value can be updated is when there is both a mutable reference to the reader ID
         // and an immutable reference to the storage.  We also guaranteed above that this reader id
         // was created by this storage.
         unsafe {
-            let pointer: &usize = &self.reader_written[reader_id.reader_id];
-            let pointer: *const usize = pointer as *const usize;
-            let pointer: *mut usize = pointer as *mut usize;
-            *pointer = self.written;
-            let pointer: &usize = &self.reader_indices[reader_id.reader_id] ;
-            let pointer: *const usize = pointer as *const usize;
-            let pointer: *mut usize = pointer as *mut usize;
-            *pointer = self.write_index;
+            let pointer: &InternalReaderId = &self.reader_internal[reader_id.reader_id];
+            let pointer: *const InternalReaderId = pointer as *const InternalReaderId;
+            let pointer: *mut InternalReaderId = pointer as *mut InternalReaderId;
+            (*pointer).written = self.written;
+            (*pointer).index = self.write_index;
         }
         StorageIterator {
             storage: &self,
             current: read_index,
             end: self.write_index,
+            started: num_written == 0,
         }
     }
 }
@@ -148,18 +217,19 @@ pub struct StorageIterator<'a, T: 'a> {
     storage: &'a RingBufferStorage<T>,
     current: usize,
     end: usize,
+    // needed when we should read the whole buffer, because then current == end for the first value
+    // needs special handling for empty iterator, needs to be forced to true for that corner case
+    started: bool,
 }
 
 impl<'a, T> Iterator for StorageIterator<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-        if self.current == self.end {
+        if self.started && self.current == self.end {
             None
         } else {
-            if self.current == self.storage.data.len() && self.end != self.storage.data.len() {
-                self.current = 0;
-            }
+            self.started = true;
             let item = &self.storage[self.current];
             self.current += 1;
             if self.current == self.storage.data.len() && self.end != self.storage.data.len() {
@@ -220,7 +290,6 @@ mod tests {
         let mut reader_id = buffer.new_reader_id();
         let data = buffer.read(&mut reader_id);
         assert_eq!(Vec::<Test>::default(), data.cloned().collect::<Vec<_>>())
-
     }
 
     #[test]
@@ -251,7 +320,12 @@ mod tests {
         buffer.drain_vec_write(&mut events(4));
         let data = buffer.read(&mut reader_id);
         assert_eq!(
-            vec![Test { id: 0 }, Test { id: 1 }, Test { id: 2 }, Test { id: 3 }],
+            vec![
+                Test { id: 0 },
+                Test { id: 1 },
+                Test { id: 2 },
+                Test { id: 3 },
+            ],
             data.cloned().collect::<Vec<_>>()
         );
     }
@@ -264,14 +338,27 @@ mod tests {
         buffer.drain_vec_write(&mut events(2));
         // we wrote 0,1,0,1, if the buffer grew correctly we'll get all of these back.
         assert_eq!(
-            vec![Test { id: 0 }, Test { id: 1 }, Test { id: 0 }, Test { id: 1 }],
+            vec![
+                Test { id: 0 },
+                Test { id: 1 },
+                Test { id: 0 },
+                Test { id: 1 },
+            ],
             buffer.read(&mut reader_id).cloned().collect::<Vec<_>>()
         );
 
-        buffer.drain_vec_write(&mut events(2));
-        buffer.drain_vec_write(&mut events(2));
+        buffer.drain_vec_write(&mut events(4));
         // After writing 4 more events the buffer should have no reason to grow beyond four.
         assert_eq!(buffer.data.len(), 4);
+        assert_eq!(
+            vec![
+                Test { id: 0 },
+                Test { id: 1 },
+                Test { id: 2 },
+                Test { id: 3 },
+            ],
+            buffer.read(&mut reader_id).cloned().collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
This ended up being a re-write of the project in a few ways, but I feel we gain lots of valuable changes here.

First off, buffer overflows are now a thing of the past.  This was accomplished by moving reader data into the buffer storage so the buffer could be dynamically resized if needed then it also uses newly introduced buffer IDs to make sure readers were only used with the correct buffer.  I still achieve the goal of permitting simultaneous reads though because the only time the corresponding reader data can be updated is during a read.  Simultaneously the only time it can be read is when the storage has a mutable reference, which guarantees there are no immutable references, which guarantees nothing is writing to the reader data.

Because we dynamically resize now we have no need for the max length value, we're only concerned with the event vector's current length.

Registering readers now requires a mutable reference, and readers are no longer `Clone`able. I feel this is fine because you typically only initialize readers once.

Thanks to @Aceeri @torkleyy and @Rhuagh for your valuable conversation on gitter that helped make this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rhuagh/shrev-rs/15)
<!-- Reviewable:end -->
