### PR TITLE
Depend on a range of parking_lot versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 - |
   travis-cargo build &&
   travis-cargo test -- --all &&
+  travis-cargo --only nightly test -- --all -Z minimal-versions &&
   travis-cargo bench &&
   travis-cargo --only stable doc
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ keywords = ["specs", "events"]
 
 [dependencies]
 derivative = "1.0.0"
-parking_lot = "0.5.5"
+parking_lot = ">=0.1.1, <0.8"


### PR DESCRIPTION
The first commit (7c1a276) changes the dependency on parking_lot to any version between 0.1.1 (inclusive) and 0.8 (exclusive). (0.1.0 isn't included as it doesn't build on stable and I didn't want to bother rebuilding everything on nightly to check).

The second commit (c0926ea) configures Travis to also test using the minimum allowed version of dependencies, so that this doesn't end in somebody accidentally breaking something.